### PR TITLE
correct a little mistake

### DIFF
--- a/include/mxx/comm_fwd.hpp
+++ b/include/mxx/comm_fwd.hpp
@@ -547,6 +547,7 @@ inline std::basic_string<CharT, Traits, Alloc> comm::recv_str(size_t size, int s
     std::basic_string<CharT, Traits, Alloc> result;
     result.resize(size);
     this->recv_into(&result[0], size, src, tag);
+    return result;
 }
 
 /***********


### PR DESCRIPTION
it seems that **comm::recv_str** at **line545** forget to return a string