### PR TITLE
Remove unused parameters in datatypes and env

### DIFF
--- a/include/mxx/datatypes.hpp
+++ b/include/mxx/datatypes.hpp
@@ -292,8 +292,8 @@ struct datatype_name {
       : mpi_name(mpi_name), c_name(c_name), typeid_name(typeid_name) {}
 
     datatype_name() {}
-    datatype_name(const datatype_name& o) = default;
-    datatype_name(datatype_name&& o) = default;
+    datatype_name(const datatype_name&) = default;
+    datatype_name(datatype_name&&) = default;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const datatype_name& n) {

--- a/include/mxx/env.hpp
+++ b/include/mxx/env.hpp
@@ -30,7 +30,7 @@
 
 namespace mxx {
 
-inline void my_mpi_errorhandler(MPI_Comm* comm, int* error_code, ...) {
+inline void my_mpi_errorhandler(MPI_Comm* /*comm*/, int* error_code, ...) {
     char buf[MPI_MAX_ERROR_STRING];
     int strlen;
     int error_class;


### PR DESCRIPTION
These changes remedy gcc warnings of unused parameters, mainly for debug builds.

In `datatype_name()`, the variable `o` seems like just a place holder. In `my_mpi_errorhandler()`, the variable `comm` is commented out, to keep the variable documented.

All tests pass with these changes.