### PR TITLE
Fix in global_scan and global_scan_inplace.

### DIFF
--- a/include/mxx/reduction.hpp
+++ b/include/mxx/reduction.hpp
@@ -741,14 +741,14 @@ void global_scan(InIterator begin, InIterator end, OutIterator out, Func func, c
         local_scan(begin, end, out, func);
         // mxx::scan
         typedef typename std::iterator_traits<OutIterator>::value_type T;
-        T sum = T();
-        if (n > 0)
-            sum = *(out+(n-1));
+        T sum = *(out+(n-1));
         T presum = exscan(sum, func, nonzero_comm, commutative);
-        // accumulate previous sum on all local elements
-        for (size_t i = 0; i < n; ++i) {
-            *o = func(presum, *o);
-            ++o;
+        if (nonzero_comm.rank() != 0) {
+            // accumulate previous sum on all local elements
+            for (size_t i = 0; i < n; ++i) {
+                *o = func(presum, *o);
+                ++o;
+            }
         }
     }
 }
@@ -773,10 +773,12 @@ inline void global_scan_inplace(Iterator begin, Iterator end, Func func, const b
         T sum = *(begin + (n-1));
         T presum = exscan(sum, func, nonzero_comm, commutative);
 
-        // accumulate previous sum on all local elements
-        for (size_t i = 0; i < n; ++i) {
-            *o = func(presum, *o);
-            ++o;
+        if (nonzero_comm.rank() != 0) {
+            // accumulate previous sum on all local elements
+            for (size_t i = 0; i < n; ++i) {
+                *o = func(presum, *o);
+                ++o;
+            }
         }
     }
 }

--- a/test/test_reductions.cpp
+++ b/test/test_reductions.cpp
@@ -247,7 +247,7 @@ TEST(MxxReduce, GlobalReduce) {
 
 TEST(MxxReduce, GlobalScan) {
     mxx::comm c;
-    // test reduce with zero elements for some processes
+    // test scan with zero elements for some processes
     size_t n = 0;
     int presize = 0;
     if (c.rank() % 2 == 0) {
@@ -270,6 +270,31 @@ TEST(MxxReduce, GlobalScan) {
     ASSERT_EQ(local.size(), result.size());
     for (size_t i = 0; i < n; ++i) {
         ASSERT_EQ(local[i]*(local[i]+1)/2, result[i]);
+    }
+}
+
+TEST(MxxReduce, GlobalScanMin) {
+    mxx::comm c;
+    // test scan with min and an array of positive
+    // elements sorted in ascending order
+    size_t n = c.size();
+    std::vector<int> local(n);
+    for (size_t i = 0; i < n; ++i) {
+        local[i] = (c.rank()*n)+i+1;
+    }
+    // test inplace scan
+    std::vector<int> local_cpy(local);
+    mxx::global_scan_inplace(local_cpy.begin(), local_cpy.end(), mxx::min<int>(), c);
+    for (size_t i = 0; i < n; ++i) {
+        // 1 is both the first as well as the minimum element
+        ASSERT_EQ(1, local_cpy[i]);
+    }
+    // test scan
+    std::vector<int> result = mxx::global_scan(local, mxx::min<int>(), c);
+    ASSERT_EQ(local.size(), result.size());
+    for (size_t i = 0; i < n; ++i) {
+        // 1 is both the first as well as the minimum element
+        ASSERT_EQ(1, result[i]);
     }
 }
 


### PR DESCRIPTION
**_Problem_**: Currently, in the `mxx::global_scan*` functions, the local scan results are updated on every process with the prefix sum from the previous process. However, the prefix sum on process 0 is just the zero-initialized value corresponding to the type. This may lead to erroneous results on process 0 in some cases, e.g. while scanning using `min` on an array if the minimum element in the array is greater than zero.
**_Solution_**: The result of `local_scan` on process 0 should not be updated with the `presum`.