### PR TITLE
Fix in stable_distribute and stable_distribute_inplace

### DIFF
--- a/test/test_distribution.cpp
+++ b/test/test_distribution.cpp
@@ -143,6 +143,16 @@ TEST(MxxDistribution, DistributeVector) {
 
     test_distribute<std::vector<int>>(size, gen, c);
     test_stable_distribute<std::vector<int>>(size, gen, c);
+
+    // create a distribution of total size smaller than
+    // the total number of processes and zero elements on the last process
+    size = (c.rank() % 2 == 0) ? 1 : 0;
+    if (c.is_last()) {
+      size = 0;
+    }
+    // XXX: test_distribute fails with an assertion error in mxx::sort
+    // test_distribute<std::vector<int>>(size, gen, c);
+    test_stable_distribute<std::vector<int>>(size, gen, c);
 }
 
 


### PR DESCRIPTION
_**Problem**_: Currently, the `mxx::stable_distribute*` functions may crash on a process with rank >= _p_ if the input size on every process with rank >= _p_  is zero **and** the global input size is less than the total number of processes. This is because the functions try to determine the index of the first element of the current partition using the result of the `mxx::exscan` which leads to a divide by zero error in the function `mxx::partition::blk_dist_buf::rank_of`.
_**Solution**_: A process should try to compute its send counts only if the input size on the process is non-zero.

I have also added a test that was failing before the fix.

