### PR TITLE
Remove extra semicolon for pedantic compilers

### DIFF
--- a/include/mxx/stream.hpp
+++ b/include/mxx/stream.hpp
@@ -103,7 +103,7 @@ inline sync_ostream sync_cerr(const mxx::comm& comm, int root = 0) {
 template <typename base_stream>
 inline sync_ostream sync_os(const mxx::comm& comm, base_stream& bs, int root = 0) {
     return comm.rank() == root ? sync_ostream(comm, root, bs) : sync_ostream(comm, root);
-};
+}
 
 // TODO: a sync ofstream
 // TODO: a sync cout/cerr which writes [rank] before every line/msg


### PR DESCRIPTION
Small change to suppress a warning in pedantic compilers (`-pedantic` flag).