### PR TITLE
Explicitly include cstdio

### DIFF
--- a/include/mxx/common.hpp
+++ b/include/mxx/common.hpp
@@ -18,6 +18,7 @@
 #define MXX_COMMON_HPP
 
 #include <mpi.h>
+#include <cstdio>
 #include <limits>
 
 namespace mxx {


### PR DESCRIPTION
When compiling a library that depends on this on MacOS Monterry with gcc and OpenMPI (both installed via homebrew) the build fails because of `cstdio` missing (see [here](https://github.com/SSAGESproject/SSAGES/issues/36)).

Everything works well when building with clang instead. But I saw no harm in explicitly including `cstdio`.